### PR TITLE
Correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Screeenfetch: 832.59 milliseconds
 Hyfetch: 1.82 seconds (💀)
 
 ### Compatability
-Currently Rsftch only works on GNU/Linux, (most) BSD distrobrutions and Mac OS, although windows support is planned.  
+Currently Rsftch only works on GNU/Linux, (most) BSD distributions and Mac OS, although windows support is planned.  
 
 #### Todo
 - [ ] Add more distros

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn help() {
     println!("{}", "Written by charklie.".italic());
     println!("\nUsage: rsftch [OPTION...]\n");
     println!("  -h,  --help       Bring up this menu");
-    println!("  -o,  --override   Override distrobrution, changes ASCII. (not implemented yet)");
+    println!("  -o,  --override   Override distribution, changes ASCII. (not implemented yet)");
     println!("  -nc, --no-color   Removes all colors and formatting.");
     println!("  -t,  --tree       Enables tree mode.");
 }


### PR DESCRIPTION
v0.2.5

![2024-03-25-210528_996x484_scrot](https://github.com/charklie/rsftch/assets/90570748/2bb0c6cc-f810-4a11-a363-be4abb07ae96)
