### PR TITLE
v0.5.0: Adding Funtoo Linux support with some Rayon parallel iterators, Funtoo rs-figlet ASCII, and clippy cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +272,12 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[package]]
+name = "figlet-rs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4742a071cd9694fc86f9fa1a08fa3e53d40cc899d7ee532295da2d085639fbc5"
 
 [[package]]
 name = "foreign-types"
@@ -745,6 +776,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,10 +846,12 @@ dependencies = [
 
 [[package]]
 name = "rsftch"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "colored",
+ "figlet-rs",
  "libmacchina",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsftch"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2021"
 authors = ["Charklie charliejohanid@gmail.com"]
 license = "MIT"
@@ -12,4 +12,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 colored = "2.1.0"
+figlet-rs = "=0.1.5"
 libmacchina = "7.2.2"
+rayon = "1.10.0"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - NixOS
 - Kali Linux
 - CachyOS
+- Funtoo Linux
 - FreeBSD
 - NetBSD
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,4 +1,7 @@
+use figlet_rs::FIGfont;
+
 use crate::fns::{get_os_release_pretty_name, uname_s};
+use crate::fonts::SMSLANT;
 
 pub fn get_distro_ascii(overriden_ascii: Option<String>) -> String {
     if get_os_release_pretty_name(overriden_ascii.clone())
@@ -104,6 +107,14 @@ pub fn get_distro_ascii(overriden_ascii: Option<String>) -> String {
         .contains("cachy")
     {
         return "  _____         __       \n / ___/__ _____/ /  __ __\n/ /__/ _ `/ __/ _ \\/ // /\n\\___/\\_,_/\\__/_//_/\\_, / \n                  /___/".to_string();
+    } else if get_os_release_pretty_name(overriden_ascii.clone())
+        .unwrap_or("".to_string())
+        .to_ascii_lowercase()
+        .contains("funtoo")
+    {
+        let smslant_font = FIGfont::from_content(SMSLANT).unwrap();
+        let ascii = smslant_font.convert("Funtoo");
+        return ascii.unwrap().to_string().trim_end().to_string();
     }
     if uname_s(overriden_ascii.clone())
         .to_ascii_lowercase()

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,0 +1,1100 @@
+// Refernce Doc on FIGlet Fonts: http://www.jave.de/figlet/figfont.html
+// FIGlet font souce can be downloaded here: http://www.figlet.org/fontdb_example.cgi?font=smslant.flf
+pub const SMSLANT: &str = r#"flf2a$ 5 4 14 15 10 0 22415
+SmSlant by Glenn Chappell 6/93 - based on Small & Slant
+Includes ISO Latin-1
+figlet release 2.1 -- 12 Aug 1994
+Permission is hereby given to modify this font, as long as the
+modifier's name is placed on a comment line.
+
+Modified by Paul Burton <solution@earthlink.net> 12/96 to include new parameter
+supported by FIGlet and FIGWin.  May also be slightly modified for better use
+of new full-width/kern/smush alternatives, but default output is NOT changed.
+
+    $@
+   $ @
+  $  @
+ $   @
+$    @@
+   __@
+  / /@
+ /_/ @
+(_)  @
+     @@
+ _ _ @
+( | )@
+|/|/ @
+$    @
+     @@
+     ____ @
+  __/ / /_@
+ /_  . __/@
+/_    __/ @
+ /_/_/    @@
+     @
+  _//@
+ (_-<@
+/ __/@
+//   @@
+ _   __@
+(_)_/_/@
+ _/_/_ @
+/_/ (_)@
+       @@
+  ____   @
+ / __/___@
+ > _/_ _/@
+|_____/  @
+         @@
+ _ @
+( )@
+|/ @
+$  @
+   @@
+    __@
+  _/_/@
+ / /  @
+/ /   @
+|_|   @@
+    _ @
+   | |@
+   / /@
+ _/_/ @
+/_/   @@
+    @
+ _/|@
+> _<@
+|/  @
+    @@
+    __ @
+ __/ /_@
+/_  __/@
+ /_/   @
+       @@
+   @
+   @
+ _ @
+( )@
+|/ @@
+     @
+ ____@
+/___/@
+ $   @
+     @@
+   @
+   @
+ _ @
+(_)@
+   @@
+     __@
+   _/_/@
+ _/_/  @
+/_/    @
+       @@
+  ___ @
+ / _ \@
+/ // /@
+\___/ @
+      @@
+  ___@
+ <  /@
+ / / @
+/_/  @
+     @@
+   ___ @
+  |_  |@
+ / __/ @
+/____/ @
+       @@
+   ____@
+  |_  /@
+ _/_ < @
+/____/ @
+       @@
+  ____@
+ / / /@
+/_  _/@
+ /_/  @
+      @@
+   ____@
+  / __/@
+ /__ \ @
+/____/ @
+       @@
+  ____@
+ / __/@
+/ _ \ @
+\___/ @
+      @@
+ ____@
+/_  /@
+ / / @
+/_/  @
+     @@
+  ___ @
+ ( _ )@
+/ _  |@
+\___/ @
+      @@
+  ___ @
+ / _ \@
+ \_, /@
+/___/ @
+      @@
+   _ @
+  (_)@
+ _   @
+(_)  @
+     @@
+   _ @
+  (_)@
+ _   @
+( )  @
+|/   @@
+  __@
+ / /@
+< < @
+ \_\@
+    @@
+      @
+  ____@
+ /___/@
+/___/ @
+      @@
+__  @
+\ \ @
+ > >@
+/_/ @
+    @@
+ ___ @
+/__ \@
+ /__/@
+(_)  @
+     @@
+  _____ @
+ / ___ \@
+/ / _ `/@
+\ \_,_/ @
+ \___/  @@
+   ___ @
+  / _ |@
+ / __ |@
+/_/ |_|@
+       @@
+   ___ @
+  / _ )@
+ / _  |@
+/____/ @
+       @@
+  _____@
+ / ___/@
+/ /__  @
+\___/  @
+       @@
+   ___ @
+  / _ \@
+ / // /@
+/____/ @
+       @@
+   ____@
+  / __/@
+ / _/  @
+/___/  @
+       @@
+   ____@
+  / __/@
+ / _/  @
+/_/    @
+       @@
+  _____@
+ / ___/@
+/ (_ / @
+\___/  @
+       @@
+   __ __@
+  / // /@
+ / _  / @
+/_//_/  @
+        @@
+   ____@
+  /  _/@
+ _/ /  @
+/___/  @
+       @@
+     __@
+ __ / /@
+/ // / @
+\___/  @
+       @@
+   __ __@
+  / //_/@
+ / ,<   @
+/_/|_|  @
+        @@
+   __ @
+  / / @
+ / /__@
+/____/@
+      @@
+   __  ___@
+  /  |/  /@
+ / /|_/ / @
+/_/  /_/  @
+          @@
+   _  __@
+  / |/ /@
+ /    / @
+/_/|_/  @
+        @@
+  ____ @
+ / __ \@
+/ /_/ /@
+\____/ @
+       @@
+   ___ @
+  / _ \@
+ / ___/@
+/_/    @
+       @@
+  ____ @
+ / __ \@
+/ /_/ /@
+\___\_\@
+       @@
+   ___ @
+  / _ \@
+ / , _/@
+/_/|_| @
+       @@
+   ____@
+  / __/@
+ _\ \  @
+/___/  @
+       @@
+ ______@
+/_  __/@
+ / /   @
+/_/    @
+       @@
+  __  __@
+ / / / /@
+/ /_/ / @
+\____/  @
+        @@
+  _   __@
+ | | / /@
+ | |/ / @
+ |___/  @
+        @@
+  _      __@
+ | | /| / /@
+ | |/ |/ / @
+ |__/|__/  @
+           @@
+   _  __@
+  | |/_/@
+ _>  <  @
+/_/|_|  @
+        @@
+ __  __@
+ \ \/ /@
+  \  / @
+  /_/  @
+       @@
+  ____@
+ /_  /@
+  / /_@
+ /___/@
+      @@
+    ___@
+   / _/@
+  / /  @
+ / /   @
+/__/   @@
+__   @
+\ \  @
+ \ \ @
+  \_\@
+     @@
+    ___@
+   /  /@
+   / / @
+ _/ /  @
+/__/   @@
+ //|@
+|/||@
+ $  @
+$   @
+    @@
+     @
+     @
+     @
+ ____@
+/___/@@
+ _ @
+( )@
+ V @
+$  @
+   @@
+      @
+ ___ _@
+/ _ `/@
+\_,_/ @
+      @@
+   __ @
+  / / @
+ / _ \@
+/_.__/@
+      @@
+     @
+ ____@
+/ __/@
+\__/ @
+     @@
+     __@
+ ___/ /@
+/ _  / @
+\_,_/  @
+       @@
+     @
+ ___ @
+/ -_)@
+\__/ @
+     @@
+   ___@
+  / _/@
+ / _/ @
+/_/   @
+      @@
+       @
+  ___ _@
+ / _ `/@
+ \_, / @
+/___/  @@
+   __ @
+  / / @
+ / _ \@
+/_//_/@
+      @@
+   _ @
+  (_)@
+ / / @
+/_/  @
+     @@
+      _ @
+     (_)@
+    / / @
+ __/ /  @
+|___/   @@
+   __  @
+  / /__@
+ /  '_/@
+/_/\_\ @
+       @@
+   __@
+  / /@
+ / / @
+/_/  @
+     @@
+       @
+  __ _ @
+ /  ' \@
+/_/_/_/@
+       @@
+      @
+  ___ @
+ / _ \@
+/_//_/@
+      @@
+     @
+ ___ @
+/ _ \@
+\___/@
+     @@
+       @
+   ___ @
+  / _ \@
+ / .__/@
+/_/    @@
+      @
+ ___ _@
+/ _ `/@
+\_, / @
+ /_/  @@
+      @
+  ____@
+ / __/@
+/_/   @
+      @@
+     @
+  ___@
+ (_-<@
+/___/@
+     @@
+  __ @
+ / /_@
+/ __/@
+\__/ @
+     @@
+      @
+ __ __@
+/ // /@
+\_,_/ @
+      @@
+      @
+ _  __@
+| |/ /@
+|___/ @
+      @@
+        @
+ _    __@
+| |/|/ /@
+|__,__/ @
+        @@
+      @
+ __ __@
+ \ \ /@
+/_\_\ @
+      @@
+       @
+  __ __@
+ / // /@
+ \_, / @
+/___/  @@
+    @
+ ___@
+/_ /@
+/__/@
+    @@
+    __@
+  _/_/@
+_/ /  @
+/ /   @
+\_\   @@
+    __@
+   / /@
+  / / @
+ / /  @
+/_/   @@
+   __  @
+   \ \ @
+   / /_@
+ _/_/  @
+/_/    @@
+ /\//@
+//\/ @
+ $   @
+$    @
+     @@
+   _  _ @
+  (_)(_)@
+ / - |  @
+/_/|_|  @
+        @@
+  _   _ @
+ (_)_(_)@
+/ __ \  @
+\____/  @
+        @@
+  _   _ @
+ (_) (_)@
+/ /_/ / @
+\____/  @
+        @@
+  _  _ @
+ (_)(_)@
+/ _ `/ @
+\_,_/  @
+       @@
+  _  _ @
+ (_)(_)@
+/ _ \  @
+\___/  @
+       @@
+  _  _ @
+ (_)(_)@
+/ // / @
+\_,_/  @
+       @@
+    ____ @
+   / _  )@
+  / /< < @
+ / //__/ @
+/_/      @@
+160  NO-BREAK SPACE
+    $@
+   $ @
+  $  @
+ $   @
+$    @@
+161  INVERTED EXCLAMATION MARK
+   _ @
+  (_)@
+ / / @
+/_/  @
+     @@
+162  CENT SIGN
+     @
+ __//@
+/ __/@
+\ _/ @
+//   @@
+163  POUND SIGN
+     __ @
+  __/__|@
+ /_ _/_ @
+(_,___/ @
+        @@
+164  CURRENCY SIGN
+   /|_/|@
+  | . / @
+ /_  |  @
+|/ |/   @
+        @@
+165  YEN SIGN
+    ____@
+  _| / /@
+ /_  __/@
+/_  __/ @
+ /_/    @@
+166  BROKEN BAR
+    __@
+   / /@
+  /_/ @
+ / /  @
+/_/   @@
+167  SECTION SIGN
+     __ @
+   _/ _)@
+  / | | @
+ | |_/  @
+(__/    @@
+168  DIAERESIS
+ _   _ @
+(_) (_)@
+ $   $ @
+$   $  @
+       @@
+169  COPYRIGHT SIGN
+   ____  @
+  / ___\ @
+ / / _/ |@
+| |__/ / @
+ \____/  @@
+170  FEMININE ORDINAL INDICATOR
+   ___ _@
+  / _ `/@
+ _\_,_/ @
+/____/  @
+        @@
+171  LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+  ____@
+ / / /@
+< < < @
+ \_\_\@
+      @@
+172  NOT SIGN
+     @
+ ____@
+/_  /@
+ /_/ @
+     @@
+173  SOFT HYPHEN
+    @
+ ___@
+/__/@
+ $  @
+    @@
+174  REGISTERED SIGN
+   ____  @
+  / __ \ @
+ / / -) |@
+| //\\ / @
+ \____/  @@
+175  MACRON
+ ____@
+/___/@
+ $   @
+$    @
+     @@
+176  DEGREE SIGN
+  __ @
+ /. |@
+|__/ @
+ $   @
+     @@
+177  PLUS-MINUS SIGN
+      __ @
+   __/ /_@
+  /_  __/@
+ __/_/_  @
+/_____/  @@
+178  SUPERSCRIPT TWO
+  __ @
+ |_ )@
+/__| @
+ $   @
+     @@
+179  SUPERSCRIPT THREE
+  ___@
+ |_ /@
+/__) @
+ $   @
+     @@
+180  ACUTE ACCENT
+ __@
+/_/@
+ $ @
+$  @
+   @@
+181  MICRO SIGN
+        @
+   __ __@
+  / // /@
+ / .,_/ @
+/_/     @@
+182  PILCROW SIGN
+  _____@
+ /    /@
+|_ / / @
+/_/_/  @
+       @@
+183  MIDDLE DOT
+   @
+ _ @
+(_)@
+$  @
+   @@
+184  CEDILLA
+   @
+   @
+   @
+ _ @
+/_)@@
+185  SUPERSCRIPT ONE
+  __@
+ < /@
+/_/ @
+$   @
+    @@
+186  MASCULINE ORDINAL INDICATOR
+   ___ @
+  / _ \@
+ _\___/@
+/____/ @
+       @@
+187  RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+____  @
+\ \ \ @
+ > > >@
+/_/_/ @
+      @@
+188  VULGAR FRACTION ONE QUARTER
+  __  __   @
+ < /_/_/___@
+/_//_//_' /@
+ /_/   /_/ @
+           @@
+189  VULGAR FRACTION ONE HALF
+  __  __  @
+ < /_/_/_ @
+/_//_/|_ )@
+ /_/ /__| @
+          @@
+190  VULGAR FRACTION THREE QUARTERS
+  ___  __   @
+ |_ /_/_/___@
+/__)/_//_' /@
+  /_/   /_/ @
+            @@
+191  INVERTED QUESTION MARK
+   _ @
+ _(_)@
+/ _/_@
+\___/@
+     @@
+192  LATIN CAPITAL LETTER A WITH GRAVE
+   __ @
+  _\_\@
+ / - |@
+/_/|_|@
+      @@
+193  LATIN CAPITAL LETTER A WITH ACUTE
+    __@
+  _/_/@
+ / - |@
+/_/|_|@
+      @@
+194  LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+    //|@
+  _|/||@
+ / - | @
+/_/|_| @
+       @@
+195  LATIN CAPITAL LETTER A WITH TILDE
+    /\//@
+  _//\/ @
+ / - |  @
+/_/|_|  @
+        @@
+196  LATIN CAPITAL LETTER A WITH DIAERESIS
+   _  _ @
+  (_)(_)@
+ / - |  @
+/_/|_|  @
+        @@
+197  LATIN CAPITAL LETTER A WITH RING ABOVE
+   (())@
+  / _ |@
+ / __ |@
+/_/ |_|@
+       @@
+198  LATIN CAPITAL LETTER AE
+   _______@
+  / _  __/@
+ / _  _/  @
+/_//___/  @
+          @@
+199  LATIN CAPITAL LETTER C WITH CEDILLA
+  _____@
+ / ___/@
+/ /__  @
+\___/  @
+/_)    @@
+200  LATIN CAPITAL LETTER E WITH GRAVE
+  __ @
+  \_\@
+ / -<@
+/__< @
+     @@
+201  LATIN CAPITAL LETTER E WITH ACUTE
+    __@
+  _/_/@
+ / -< @
+/__<  @
+      @@
+202  LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+   //|@
+  |/||@
+ / -< @
+/__<  @
+      @@
+203  LATIN CAPITAL LETTER E WITH DIAERESIS
+  _  _ @
+ (_)(_)@
+ / -<  @
+/__<   @
+       @@
+204  LATIN CAPITAL LETTER I WITH GRAVE
+   __  @
+  _\_\ @
+ /_ __/@
+/____/ @
+       @@
+205  LATIN CAPITAL LETTER I WITH ACUTE
+     __@
+  __/_/@
+ /_ __/@
+/____/ @
+       @@
+206  LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+    //|@
+  _|/||@
+ /_ __/@
+/____/ @
+       @@
+207  LATIN CAPITAL LETTER I WITH DIAERESIS
+   _  _ @
+  (_)(_)@
+ /_ __/ @
+/____/  @
+        @@
+208  LATIN CAPITAL LETTER ETH
+   ____ @
+ _/ __ \@
+/_ _// /@
+/_____/ @
+        @@
+209  LATIN CAPITAL LETTER N WITH TILDE
+     /\//@
+  __//\/ @
+ /  |/ / @
+/_/|__/  @
+         @@
+210  LATIN CAPITAL LETTER O WITH GRAVE
+  __  @
+ _\_\ @
+/ __ \@
+\____/@
+      @@
+211  LATIN CAPITAL LETTER O WITH ACUTE
+    __@
+ __/_/@
+/ __ \@
+\____/@
+      @@
+212  LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+   //|@
+ _|/||@
+/ __ \@
+\____/@
+      @@
+213  LATIN CAPITAL LETTER O WITH TILDE
+   /\//@
+ _//\/ @
+/ __ \ @
+\____/ @
+       @@
+214  LATIN CAPITAL LETTER O WITH DIAERESIS
+  _   _ @
+ (_)_(_)@
+/ __ \  @
+\____/  @
+        @@
+215  MULTIPLICATION SIGN
+     @
+ /|/|@
+ > < @
+|/|/ @
+     @@
+216  LATIN CAPITAL LETTER O WITH STROKE
+  _____ @
+ / _// \@
+/ //// /@
+\_//__/ @
+        @@
+217  LATIN CAPITAL LETTER U WITH GRAVE
+   __  @
+ __\_\ @
+/ /_/ /@
+\____/ @
+       @@
+218  LATIN CAPITAL LETTER U WITH ACUTE
+     __@
+ __ /_/@
+/ /_/ /@
+\____/ @
+       @@
+219  LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+    //|@
+ __|/||@
+/ /_/ /@
+\____/ @
+       @@
+220  LATIN CAPITAL LETTER U WITH DIAERESIS
+  _   _ @
+ (_) (_)@
+/ /_/ / @
+\____/  @
+        @@
+221  LATIN CAPITAL LETTER Y WITH ACUTE
+   __@
+__/_/@
+\ V /@
+ /_/ @
+     @@
+222  LATIN CAPITAL LETTER THORN
+   __ @
+  / / @
+ / -_)@
+/_/   @
+      @@
+223  LATIN SMALL LETTER SHARP S
+    ____ @
+   / _  )@
+  / /< < @
+ / //__/ @
+/_/      @@
+224  LATIN SMALL LETTER A WITH GRAVE
+  __  @
+ _\_\_@
+/ _ `/@
+\_,_/ @
+      @@
+225  LATIN SMALL LETTER A WITH ACUTE
+    __@
+ __/_/@
+/ _ `/@
+\_,_/ @
+      @@
+226  LATIN SMALL LETTER A WITH CIRCUMFLEX
+   //|@
+ _|/||@
+/ _ `/@
+\_,_/ @
+      @@
+227  LATIN SMALL LETTER A WITH TILDE
+   /\//@
+ _//\/ @
+/ _ `/ @
+\_,_/  @
+       @@
+228  LATIN SMALL LETTER A WITH DIAERESIS
+  _  _ @
+ (_)(_)@
+/ _ `/ @
+\_,_/  @
+       @@
+229  LATIN SMALL LETTER A WITH RING ABOVE
+   __ @
+ _(())@
+/ _ `/@
+\_,_/ @
+      @@
+230  LATIN SMALL LETTER AE
+         @
+ ___ ___ @
+/ _ ` -_)@
+\_,____/ @
+         @@
+231  LATIN SMALL LETTER C WITH CEDILLA
+     @
+ ____@
+/ __/@
+\__/ @
+/_)  @@
+232  LATIN SMALL LETTER E WITH GRAVE
+  __ @
+ _\_\@
+/ -_)@
+\__/ @
+     @@
+233  LATIN SMALL LETTER E WITH ACUTE
+   __@
+ _/_/@
+/ -_)@
+\__/ @
+     @@
+234  LATIN SMALL LETTER E WITH CIRCUMFLEX
+  //|@
+ |/||@
+/ -_)@
+\__/ @
+     @@
+235  LATIN SMALL LETTER E WITH DIAERESIS
+ _  _ @
+(_)(_)@
+/ -_) @
+\__/  @
+      @@
+236  LATIN SMALL LETTER I WITH GRAVE
+  __ @
+  \_\@
+ / / @
+/_/  @
+     @@
+237  LATIN SMALL LETTER I WITH ACUTE
+   __@
+  /_/@
+ / / @
+/_/  @
+     @@
+238  LATIN SMALL LETTER I WITH CIRCUMFLEX
+   //|@
+  |/||@
+ / /  @
+/_/   @
+      @@
+239  LATIN SMALL LETTER I WITH DIAERESIS
+ _   _ @
+(_)_(_)@
+ / /   @
+/_/    @
+       @@
+240  LATIN SMALL LETTER ETH
+   _||_@
+ __ || @
+/ _` | @
+\___/  @
+       @@
+241  LATIN SMALL LETTER N WITH TILDE
+    /\//@
+  _//\/ @
+ / _ \  @
+/_//_/  @
+        @@
+242  LATIN SMALL LETTER O WITH GRAVE
+  __ @
+ _\_\@
+/ _ \@
+\___/@
+     @@
+243  LATIN SMALL LETTER O WITH ACUTE
+   __@
+ _/_/@
+/ _ \@
+\___/@
+     @@
+244  LATIN SMALL LETTER O WITH CIRCUMFLEX
+   //|@
+ _|/||@
+/ _ \ @
+\___/ @
+      @@
+245  LATIN SMALL LETTER O WITH TILDE
+   /\//@
+ _//\/ @
+/ _ \  @
+\___/  @
+       @@
+246  LATIN SMALL LETTER O WITH DIAERESIS
+  _  _ @
+ (_)(_)@
+/ _ \  @
+\___/  @
+       @@
+247  DIVISION SIGN
+   _ @
+ _(_)@
+/___/@
+(_)  @
+     @@
+248  LATIN SMALL LETTER O WITH STROKE
+     @
+ ___ @
+/ //\@
+\//_/@
+     @@
+249  LATIN SMALL LETTER U WITH GRAVE
+   __ @
+ __\_\@
+/ // /@
+\_,_/ @
+      @@
+250  LATIN SMALL LETTER U WITH ACUTE
+    __@
+ __/_/@
+/ // /@
+\_,_/ @
+      @@
+251  LATIN SMALL LETTER U WITH CIRCUMFLEX
+   //|@
+ _|/||@
+/ // /@
+\_,_/ @
+      @@
+252  LATIN SMALL LETTER U WITH DIAERESIS
+  _  _ @
+ (_)(_)@
+/ // / @
+\_,_/  @
+       @@
+253  LATIN SMALL LETTER Y WITH ACUTE
+     __@
+  __/_/@
+ / // /@
+ \_, / @
+/___/  @@
+254  LATIN SMALL LETTER THORN
+    __ @
+   / / @
+  / _ \@
+ / .__/@
+/_/    @@
+255  LATIN SMALL LETTER Y WITH DIAERESIS
+   _  _ @
+  (_)(_)@
+ / // / @
+ \_, /  @
+/___/   @@
+"#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 
 pub mod ascii;
 pub mod fns;
+pub mod fonts;
 
 use crate::ascii::*;
 use crate::fns::*;
@@ -28,7 +29,7 @@ fn main() {
             }
             "-o" | "--override" => {
                 if count + 1 < args.len() {
-                    overriden_ascii = Some(std::mem::replace(&mut args[count + 1], String::new()));
+                    overriden_ascii = Some(std::mem::take(&mut args[count + 1]));
                 } else {
                     println!("{} Missing argument for override.\n", "[ERROR]".red());
                 }
@@ -59,17 +60,33 @@ enum Color {
 }
 
 fn print_data(infos: &InfoItem, connector: &'static str) -> String {
-  let arrow = "~>";
-  let coloreds = match infos.color {
-    Color::Green => (connector.green().to_string(), infos.icon.green().to_string(), arrow.green().to_string()),
-    Color::Red => (connector.bright_red().to_string(), infos.icon.bright_red().to_string(), arrow.bright_red().to_string()),
-    Color::Purple => (connector.purple().to_string(), infos.icon.purple().to_string(), arrow.purple().to_string()),
-    Color::NoColor => (connector.to_string(), "".to_string(), arrow.to_string()),
-  };
+    let arrow = "~>";
+    let coloreds = match infos.color {
+        Color::Green => (
+            connector.green().to_string(),
+            infos.icon.green().to_string(),
+            arrow.green().to_string(),
+        ),
+        Color::Red => (
+            connector.bright_red().to_string(),
+            infos.icon.bright_red().to_string(),
+            arrow.bright_red().to_string(),
+        ),
+        Color::Purple => (
+            connector.purple().to_string(),
+            infos.icon.purple().to_string(),
+            arrow.purple().to_string(),
+        ),
+        Color::NoColor => (connector.to_string(), "".to_string(), arrow.to_string()),
+    };
 
-  let alignment_space = " ".repeat(infos.alignment_space as usize);
+    let alignment_space = " ".repeat(infos.alignment_space as usize);
 
-  format!("{}{}  {}{}{}  {}", coloreds.0, coloreds.1, infos.title, alignment_space, coloreds.2, infos.value).to_string()
+    format!(
+        "{}{}  {}{}{}  {}",
+        coloreds.0, coloreds.1, infos.title, alignment_space, coloreds.2, infos.value
+    )
+    .to_string()
 }
 
 fn info(formatting: bool, overriden_ascii: Option<String>, margin: i8) {
@@ -117,7 +134,7 @@ fn info(formatting: bool, overriden_ascii: Option<String>, margin: i8) {
         value: get_packages(),
         color: Color::Green,
     };
-    
+
     let user = InfoItem {
         title: "user",
         alignment_space: 4,
@@ -141,7 +158,7 @@ fn info(formatting: bool, overriden_ascii: Option<String>, margin: i8) {
         value: get_wm(),
         color: Color::Red,
     };
-    
+
     let cpu = InfoItem {
         title: "cpu",
         alignment_space: 5,
@@ -168,7 +185,7 @@ fn info(formatting: bool, overriden_ascii: Option<String>, margin: i8) {
         },
         color: Color::Purple,
     };
-    
+
     let gpu = InfoItem {
         title: "gpu",
         alignment_space: 5,
@@ -184,19 +201,19 @@ fn info(formatting: bool, overriden_ascii: Option<String>, margin: i8) {
     let infos1 = vec![os, hostname, shell, kernel, packs];
     let infos2 = vec![user, term, de];
     let infos3 = vec![cpu, gpu, mem, uptime];
-    let mut info_sets = vec![infos1, infos2, infos3];
+    let mut info_sets = [infos1, infos2, infos3];
 
     println!("{}", distroascii);
 
     for (idx, infos) in info_sets.iter_mut().enumerate() {
         if idx > 0 {
-            println!("");
+            println!();
         }
         loop_over_data(infos, margin_spaces.clone(), formatting)
     }
 }
 
-fn loop_over_data(list: &mut Vec<InfoItem>, margin: String, formatting: bool) {
+fn loop_over_data(list: &mut [InfoItem], margin: String, formatting: bool) {
     let last = list.len();
     for (idx, item) in list.iter_mut().enumerate() {
         if !item.value.is_empty() {
@@ -213,7 +230,7 @@ fn loop_over_data(list: &mut Vec<InfoItem>, margin: String, formatting: bool) {
             } else {
                 connector = "├─";
             }
-            
+
             println!("{}{}", margin, print_data(item, connector));
         }
     }


### PR DESCRIPTION
Summary
=======
* v0.5.0 version bump of `rsftch`
* This adds full support for Funtoo Linux into `rsftch` crate with a collection of other improvements and changes:
  * Funtoo Linux now works as a supported OS
  * It's ASCII text is provided by the [figlet-rs crate](https://crates.io/crates/figlet-rs), which is a pure and zero-dep Rust implementation of FIGlet ASCII art generator.
    * I was able to derive the the FIGLet font being used is `smslant`. From there I was able to pull the source of the `smslant` FIGLet font and embed it directly as a Rust String literal, which is most efficient to use with figlet-rs.
    * This implementation could eventually replace the other ASCII art but not until https://github.com/yuanbohan/rs-figlet/issues/9 is implemented in upstream figlet-rs, which should fix the horizontal smushing layout functionality and generate the same _smushed_ formatting that the current `src/ascii.rs` ASCII OS name strings have.
  * While adding Funtoo support I also took the opportunity to add some very minimal parallelization optimizations to some iterators using [Rayon](https://docs.rs/rayon/latest/rayon/iter/) in two functions within the `src/fns.rs` mod:
    * `get_package_managers` -- This function is now fully parallelized.
      * Note that running or attempting to run each of these package managers even if they do not exist is probably not the most efficient, but this saves some milliseconds with Rayon.
      * Also as discovered below in Performance Improvements section, running `--version` on a package manager can be not optimized for speed and is highly dependent on the package manager implementation.
      * Future improvement: Using `--help` CLI argument is probably a safer bet (--help should not be invoking other more timely functions within the package manager CLI), but will have to be measured and tested for each distribution specific package manager.
    * `get_packages` -- This function is now fully parallelized.
      * This is an interesting function. There is probably a better way to derive which package manager to use but if one has multiple package managers, which is a peculiar scenario in Linux distributions but totally possible, this should now be parallelized in calculating package count across all `installed_managers` using Rayon iterators.
      * Added Funtoo detection for the `emerge` package manager match section, which uses a more performant _packages installed_ discovery methodology (see Performance Improvements section for details)

Some other changes that do not affect code behavior:
* `rustfmt` ran a whole bunch of formatting cleanups on files I edited, which in some areas make parts of the code more readable
* I safely fixed all `cargo clippy` errors except for two remaining ones, which are were pre-existing!

Testing
======

- There are no `cargo tests` (these should be added later), so testing of these changes was systematic and thorough.
- These changes were fully developed on Funtoo Linux with Rust 1.77.2:
```
/bin/cat /etc/os-release
ID="funtoo"
NAME="Funtoo"
PRETTY_NAME="Funtoo Linux"
ANSI_COLOR="0;34"
HOME_URL="https://www.funtoo.org"
BUG_REPORT_URL="https://bugs.funtoo.org"

rustc --version
rustc 1.77.2 (25ef9e3d8 2024-04-09)
```

My testing methodology is quite simple:
* `cargo build --release`
* `time ./target/release/rsftch`
![shot-2024-04-29_02-19-58](https://github.com/charklie/rsftch/assets/700847/344f3abe-b807-4ca3-b75c-2d7797b7fa5c)
* Verify ASCII text generation matches for all OS types:
```
for os in $(git grep contains src/ascii.rs | cut -d'"' -f2 | xargs) ; do ./target/release/rsftch -o $os &>/dev/null && echo $? ; done
0
0
0
0
0
0
0
0
0
0
0
0
0
0
0
0
0
0
0
0
```

Performance improvements
=====================
Upon initially implementing Funtoo support I noticed that execution performance was pretty bad with the current `rsftch` on Funtoo Linux, even with a fully optimized release build:
```
hyperfine -w 5 -M 15 "rsftch"
Benchmark 1: rsftch
  Time (mean ± σ):     810.8 ms ±   5.3 ms    [User: 575.2 ms, System: 144.8 ms]
  Range (min … max):   802.8 ms … 820.0 ms    10 runs
```
Upon further investigation the culprit was `emerge` package manager when invoked with the `--version` CLI argument
```
time emerge --version
Portage 3.0.14 (python 3.9.19-final-0, funtoo/1.0/linux-gnu/arch/x86-64bit, gcc-12.3.0, glibc-2.33-r3, 6.5.13_p1-debian-sources x86_64)

real	0m0.638s

hyperfine -w 5 -M 15 "emerge --version"
Benchmark 1: emerge --version
  Time (mean ± σ):     625.1 ms ±   3.5 ms    [User: 525.8 ms, System: 99.9 ms]
  Range (min … max):   619.3 ms … 632.4 ms    10 runs
```
That is pretty large performance hit for a `--version` argument. Fortunately there are other more performant ways to derive the amount of installed packages on a Gentoo-like Portage based Linux system. One in particular is just using a deterministic `find` search on `/var/db/pkg/`
```
hyperfine -w 5 -M 15 "find /var/db/pkg/ -name PF | wc -l"
Benchmark 1: find /var/db/pkg/ -name PF | wc -l
  Time (mean ± σ):      25.1 ms ±   0.3 ms    [User: 9.4 ms, System: 16.4 ms]
  Range (min … max):    24.5 ms …  25.7 ms    15 runs
```
That is much much faster and more efficient and it gets you an more accurate package install count:
```
find /var/db/pkg/ -name PF | wc -l
1423

qlist -I | wc -l
(null)qlist(null): ignoring parent with unknown repo in profile /var/git/meta-repo/kits/core-kit/profiles/funtoo/1.0/linux-gnu:
(null)qlist(null): ignoring parent with unknown repo in profile /var/git/meta-repo/kits/core-kit/profiles/funtoo/1.0/linux-gnu: # Inherit gentoo's arch specific entries, which are moved from
1422
```
Notice how `qlist` command failed on some random parsing of a package. The same can happen with emerge. Overall using `find` in this scenario is more better and faster. A findutils C implementation is faster than Portage's Python one.

Okay so after all these fixes plus some very small parallelization with Rayon, the new performance on Funtoo Linux for `rsftch` is far better:
```
hyperfine -w 5 -M 15 "./target/release/rsftch"
Benchmark 1: ./target/release/rsftch
  Time (mean ± σ):     192.8 ms ±   1.8 ms    [User: 133.6 ms, System: 62.2 ms]
  Range (min … max):   189.8 ms … 195.7 ms    15 run
```