### PR TITLE
apt to dpkg patch

### DIFF
--- a/src/fns.rs
+++ b/src/fns.rs
@@ -358,7 +358,7 @@ pub fn get_packages() -> String {
                 }
             }
             "apt" => {
-                // dpkg --get-selections | grep install
+                // dpkg --get-selections | grep -w install
                 if let Ok(output) = Command::new("dpkg")
                     .args(["--get-selections"])
                     .stdout(Stdio::piped())


### PR DESCRIPTION
Using `apt list --installed` generates the warning `WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`.

To avoid this, `dpkg` can be used since it is CLI stable. In particular, `dpkg --get-selections` with no arguments returns all installed packages (but also those marked as "deinstall", so a `grep` is necessary). The full command will be: `dpkg --get-selections | grep -w install | wc -l`.

Reference to [CLI stable apt alternatives](https://askubuntu.com/questions/445384/what-is-the-difference-between-apt-and-apt-get/446484#446484)